### PR TITLE
Make integration permeable to injection

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -97,39 +97,15 @@ class Client
      */
     protected function setupClient(): void
     {
-        $integrationConfig = (array)Configure::consume('Sentry.integrations');
         $config = (array)Configure::read('Sentry');
         if (!Hash::check($config, 'dsn')) {
             throw new RuntimeException('Sentry DSN not provided.');
         }
-
-        $config += ['integrations' => $this->buildIntegrations($integrationConfig)];
 
         init($config);
         $this->hub = SentrySdk::getCurrentHub();
 
         $event = new Event('CakeSentry.Client.afterSetup', $this);
         $this->getEventManager()->dispatch($event);
-    }
-
-    /**
-     * Build configured integrations
-     *
-     * Config should be written as `Sentry.integrations`.
-     * The content is in the following form
-     * key: IntegrationClassName, value: Options
-     *
-     * @example $integrationConfig = [IgnoreErrorsIntegration => ['ignore_exceptions' => \RuntimeException::class]]
-     * @param array<string, array> $integrationConfig Integration with options map
-     * @return array<\Sentry\Integration\IntegrationInterface>
-     */
-    protected function buildIntegrations(array $integrationConfig): array
-    {
-        $integrations = [];
-        foreach ($integrationConfig as $integration => $options) {
-            $integrations[] = new $integration($options);
-        }
-
-        return $integrations;
     }
 }

--- a/tests/TestCase/Http/ClientTest.php
+++ b/tests/TestCase/Http/ClientTest.php
@@ -6,7 +6,6 @@ namespace Connehito\CakeSentry\Test\TestCase\Http;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
-use Cake\Http\Exception\NotFoundException;
 use Cake\TestSuite\TestCase;
 use Closure;
 use Connehito\CakeSentry\Http\Client;
@@ -18,7 +17,6 @@ use ReflectionProperty;
 use RuntimeException;
 use Sentry\ClientInterface;
 use Sentry\EventId;
-use Sentry\Integration\IgnoreErrorsIntegration;
 use Sentry\Options;
 use Sentry\Severity;
 use Sentry\State\Hub;
@@ -70,28 +68,6 @@ final class ClientTest extends TestCase
         $options = $subject->getHub()->getClient()->getOptions();
 
         $this->assertSame('test-server', $options->getServerName());
-    }
-
-    /**
-     * Check constructor set up integrations
-     */
-    public function testSetupClientSetIntegrations(): void
-    {
-        $ignoreErrors = [NotFoundException::class];
-        Configure::write('Sentry.integrations', [
-            IgnoreErrorsIntegration::class => [
-                'ignore_exceptions' => $ignoreErrors,
-            ],
-        ]);
-
-        $subject = new Client([]);
-
-        $actualIntegration = $subject->getHub()->getIntegration(IgnoreErrorsIntegration::class);
-        $actualIntegrationProperty = new ReflectionProperty($actualIntegration, 'options');
-        $actualIntegrationProperty->setAccessible(true);
-        $actualIntegrationOption = $actualIntegrationProperty->getValue($actualIntegration);
-
-        $this->assertSame($ignoreErrors, $actualIntegrationOption['ignore_exceptions']);
     }
 
     /**

--- a/tests/test_app/app/config/sentry.php
+++ b/tests/test_app/app/config/sentry.php
@@ -7,11 +7,11 @@ return [
     'Sentry' => [
         'dsn' => env('SENTRY_DSN'),
         'integrations' => [
-            IgnoreErrorsIntegration::class => [
+            new IgnoreErrorsIntegration([
                 'ignore_exceptions' => [
                     NotFoundException::class,
                 ],
-            ],
+            ]),
         ],
     ],
 ];


### PR DESCRIPTION
The handling of SentrySDK configuration has been changed.

The `integration` option item used to be instantiated separately, but now it is no longer treated as a special case and the configuration can be passed transparently.
Originally, the intent was to not require users to have detailed knowledge of Sentry SDK's internal implementation. However, since these are features intended for skilled users, we believe it is appropriate to make them intuitive for those who have the knowledge to operate them.